### PR TITLE
Fix routes in GruntFile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,9 +82,9 @@ module.exports = function(grunt) {
       extlibs: {
         src: [
           'js/extlibs/three-js-examples.js',
-          'vendor/stats.js/src/Stats.js',
-          'vendor/tweenjs/build/tween.min.js',
-          'vendor/imagesloaded.pkgd.js',
+          'vendor/stats.js/build/stats.min.js',
+          'vendor/tweenjs/src/Tween.js',
+          'vendor/imagesloaded/imagesloaded.pkgd.js',
           'vendor/handlebars/handlebars.js',
           'vendor/javascript-state-machine/state-machine.js',
           'vendor/jScrollPane/script/jquery.jscrollpane.js',

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,6 @@
   ],
   "dependencies": {
     "markdown-js": "~0.6.2",
-    "threejs": "*",
     "handlebars": "~1.3.0",
     "font-awesome": "~4.1.0",
     "jScrollPane": "~2.0.14",


### PR DESCRIPTION
The routes in Gruntfile.js are outdated and cause errors on the build. The
three.js dependency on bower.js is removed because now it uses the three
CDN